### PR TITLE
Remove unused labels

### DIFF
--- a/SYNauth.c
+++ b/SYNauth.c
@@ -529,7 +529,6 @@ int set_otp(u8 *PAYLOAD, struct sk_buff *skb,
 
   // Level 4 checksum
   l4_send_check(skb, iph);
-exit_success:
 
 #ifdef DEBUG
   if (DBGLVL >= 1)

--- a/SYNgate_netfilter.c
+++ b/SYNgate_netfilter.c
@@ -542,7 +542,6 @@ static u8 validate_params(void)
       goto exit_error;
     }
 
-exit_success:
   return 0;
 
 exit_error:
@@ -598,7 +597,6 @@ static u8 validate_dstnet(void)
       dstnet_addr[i] = htonl(dstnet_addr[i]);
     }
 
-exit_success:
   return 0;
 
 exit_error:
@@ -623,7 +621,6 @@ static u8 validate_psk(void)
       psklen[i] = len;
     }
 
-exit_success:
   return 0;
 
 exit_error:
@@ -646,7 +643,6 @@ static u8 validate_precision(void)
         }
     }
 
-exit_success:
   return 0;
 
 exit_error:
@@ -669,7 +665,6 @@ static u8 validate_antispoof(void)
         }
     }
 
-exit_success:
   return 0;
 
 exit_error:
@@ -692,7 +687,6 @@ static u8 validate_udp(void)
         }
     }
 
-exit_success:
   return 0;
 
 exit_error:


### PR DESCRIPTION
Remove unused labels to avoid compilation warnings.

Fixes #16 