### PR TITLE
Test presence of conntrack module at insert time

### DIFF
--- a/SYNgate_netfilter.c
+++ b/SYNgate_netfilter.c
@@ -802,10 +802,10 @@ static u8 check_udp_blacklist(struct udphdr *udph)
 // Logs UDP module error
 static void logs_udp_error(void)
 {
-  printk(KERN_INFO "%s: Looks like some modules needed for"
+  printk(KERN_INFO "%s: Looks like some modules needed for "
          "UDP tracking are missing\n", DBGTAG);
   printk(KERN_INFO "%s: You may try the following command:\n", DBGTAG);
-  printk(KERN_INFO "%s:   # iptables -A OUTPUT -m conntrack -p udp "
+  printk(KERN_INFO "%s:   # sudo iptables -A OUTPUT -m conntrack -p udp "
          "--ctstate NEW,RELATED,ESTABLISHED -j ACCEPT\n", DBGTAG);
 }
 

--- a/SYNgate_netfilter.h
+++ b/SYNgate_netfilter.h
@@ -156,3 +156,12 @@ static u8 process_tcp_out(struct sk_buff *skb, struct iphdr *iph,
  */
 static u8 process_udp_out(struct sk_buff *skb, struct iphdr *iph,
                           struct udphdr *udph, int i);
+
+/**
+ *  logs_udp_error - logs an error
+ *
+ *  When UDP protocol is enabled, a CONNTRACK module (and a CONNTRACK rule)
+ *  is needed. This just prints out an error when this condition is not
+ *  satisfied
+ */
+static void logs_udp_error(void);

--- a/SYNwall_netfilter.c
+++ b/SYNwall_netfilter.c
@@ -1229,10 +1229,10 @@ exit_drop_udpin:
 // Logs UDP module error
 static void logs_udp_error(void)
 {
-  printk(KERN_INFO "%s: Looks like some modules needed for"
+  printk(KERN_INFO "%s: Looks like some modules needed for "
          "UDP tracking are missing\n", DBGTAG);
   printk(KERN_INFO "%s: You may try the following command:\n", DBGTAG);
-  printk(KERN_INFO "%s:   # iptables -A OUTPUT -m conntrack -p udp "
+  printk(KERN_INFO "%s:   # sudo iptables -A OUTPUT -m conntrack -p udp "
          "--ctstate NEW,RELATED,ESTABLISHED -j ACCEPT\n", DBGTAG);
 }
 

--- a/SYNwall_netfilter.h
+++ b/SYNwall_netfilter.h
@@ -156,3 +156,12 @@ static u8 process_udp_out(struct sk_buff *skb, struct iphdr *iph,
  */
 static u8 process_udp_in(struct sk_buff *skb, struct iphdr *iph,
                          struct udphdr *udph);
+
+/**
+ *  logs_udp_error - logs an error
+ *
+ *  When UDP protocol is enabled, a CONNTRACK module (and a CONNTRACK rule)
+ *  is needed. This just prints out an error when this condition is not
+ *  satisfied 
+ */
+static void logs_udp_error(void);


### PR DESCRIPTION
Fix for Issue #19 
This logs errors and stop the load if some modules required for UDP tracking are needed