### PR TITLE
tests: fix tabs with spaces

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -12,7 +12,7 @@ message = b'CANYOUREAD'
 
 def main(host,proto):
     if proto == 'tcp':
-	print('[+] Testing TCP protocol')
+        print('[+] Testing TCP protocol')
         try:
             Thread(target=start_tcp_server, args=(host, port, message)).start()
         except:
@@ -26,7 +26,7 @@ def main(host,proto):
         time.sleep(1)
 
     if proto == 'udp':
-	print('[+] Testing UDP protocol')
+        print('[+] Testing UDP protocol')
         try:
             Thread(target=start_udp_server, args=(host, port, message)).start()
         except:


### PR DESCRIPTION
Running tests I got this error:
```
python tests/test.py tcp `ip route get 8.8.8.8 | head -1 | sed -n "s/.*src \([0-9.]\+\).*/\1/p"`
  File "tests/test.py", line 15
    print('[+] Testing TCP protocol')
                                    ^
TabError: inconsistent use of tabs and spaces in indentation
```
Changed "tabs" with spaces.