### PR TITLE
Check if module is loaded without using find_module function

### DIFF
--- a/SYNgate_netfilter.c
+++ b/SYNgate_netfilter.c
@@ -687,7 +687,6 @@ exit_error:
 // It returns 0 if success, otherwise 1
 static u8 validate_udp(void)
 {
-  struct module *mod;
   uint8_t udp_used = 0;
   int i;
 
@@ -708,8 +707,7 @@ static u8 validate_udp(void)
   // Check for needed modules (for UDP protocol)
   if (udp_used == 1)
     {
-      mod = find_module("xt_conntrack");
-      if (!mod)
+      if (!module_is_loaded("xt_conntrack"))
         {
           logs_udp_error();
           goto exit_error;
@@ -807,6 +805,20 @@ static void logs_udp_error(void)
   printk(KERN_INFO "%s: You may try the following command:\n", DBGTAG);
   printk(KERN_INFO "%s:   # sudo iptables -A OUTPUT -m conntrack -p udp "
          "--ctstate NEW,RELATED,ESTABLISHED -j ACCEPT\n", DBGTAG);
+}
+
+// Check if module for UDP is loaded
+static u8 module_is_loaded(const char *name)
+{
+  struct module *list_mod = NULL;
+  list_for_each_entry(list_mod, THIS_MODULE->list.prev, list)
+  {
+      if (strcmp(list_mod->name, name) == 0)
+      {
+        return 1;
+      }
+  }
+  return 0;
 }
 
 module_init(SYNgate_init);

--- a/SYNgate_netfilter.h
+++ b/SYNgate_netfilter.h
@@ -165,3 +165,10 @@ static u8 process_udp_out(struct sk_buff *skb, struct iphdr *iph,
  *  satisfied
  */
 static void logs_udp_error(void);
+
+/**
+ *  module_is_loaded - verify if a module is already loaded
+ *
+ *  Returns 1 if module is loaded, 0 otherwise.
+ */
+static u8 module_is_loaded(const char *name);

--- a/SYNwall_netfilter.c
+++ b/SYNwall_netfilter.c
@@ -516,7 +516,6 @@ exit_drop:
 // Load the module
 static int __init SYNwall_init(void)
 {
-  struct module *mod;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
   int random_res;
@@ -533,13 +532,13 @@ static int __init SYNwall_init(void)
   // Check for needed modules (for UDP protocol)
   if (enable_udp == 1)
     {
-      mod = find_module("xt_conntrack");
-      if (!mod)
+      if (!module_is_loaded("xt_conntrack"))
         {
           logs_udp_error();
           goto exit_error;
         }
     }
+
   // Define PAYLOADLEN depending on psk length
   PAYLOADLEN = DIGEST + psklen;
 
@@ -1234,6 +1233,20 @@ static void logs_udp_error(void)
   printk(KERN_INFO "%s: You may try the following command:\n", DBGTAG);
   printk(KERN_INFO "%s:   # sudo iptables -A OUTPUT -m conntrack -p udp "
          "--ctstate NEW,RELATED,ESTABLISHED -j ACCEPT\n", DBGTAG);
+}
+
+// Check if module for UDP is loaded
+static u8 module_is_loaded(const char *name)
+{
+  struct module *list_mod = NULL;
+  list_for_each_entry(list_mod, THIS_MODULE->list.prev, list)
+  {
+      if (strcmp(list_mod->name, name) == 0)
+      {
+        return 1;
+      }
+  }
+  return 0;
 }
 
 #ifdef DEBUG

--- a/SYNwall_netfilter.h
+++ b/SYNwall_netfilter.h
@@ -165,3 +165,10 @@ static u8 process_udp_in(struct sk_buff *skb, struct iphdr *iph,
  *  satisfied 
  */
 static void logs_udp_error(void);
+
+/**
+ *  module_is_loaded - verify if a module is already loaded
+ *
+ *  Returns 1 if module is loaded, 0 otherwise.
+ */
+static u8 module_is_loaded(const char *name);


### PR DESCRIPTION
Fixes #27 

Tested only on 5.14 and 3.10 kernels. It needs more test cases.